### PR TITLE
feat(autofinish): add Autofinish Nexus and command center widget

### DIFF
--- a/src/app/autofinish-nexus/page.tsx
+++ b/src/app/autofinish-nexus/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from 'next';
+import { APP_VERSION, AUTOFINISH_COUNT, AUTOFINISH_TARGET, KOMPANIJA } from '@/lib/constants';
+import {
+  getAutofinishHealthScore,
+  getAutofinishReleaseReadiness,
+  getAutofinishErrorBudget,
+  getAutofinishDoraMetrics,
+} from '@/lib/autofinish-petlja';
+
+export const metadata: Metadata = {
+  title: 'Autofinish Nexus',
+  description: 'Operativni sazetak autofinish stanja kroz kljucne metrike i API ulaze.',
+};
+
+export default function AutofinishNexusPage() {
+  const healthScore = getAutofinishHealthScore();
+  const readiness = getAutofinishReleaseReadiness();
+  const budget = getAutofinishErrorBudget();
+  const dora = getAutofinishDoraMetrics();
+
+  const progressPct = Math.min(100, Math.round((AUTOFINISH_COUNT / AUTOFINISH_TARGET) * 100));
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100 p-6">
+      <section className="mx-auto max-w-5xl space-y-6">
+        <header className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          <p className="text-xs uppercase tracking-[0.25em] text-cyan-300">Autofinish Nexus</p>
+          <h1 className="mt-2 text-3xl font-semibold">Kontrolni centar autofinish ciklusa</h1>
+          <p className="mt-2 text-sm text-slate-400">
+            {KOMPANIJA} • Verzija {APP_VERSION} • Iteracija #{AUTOFINISH_COUNT}
+          </p>
+        </header>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900 p-6" aria-label="Globalni progres">
+          <div className="mb-2 flex items-center justify-between text-sm text-slate-400">
+            <span>Progres ka targetu</span>
+            <span className="font-semibold text-cyan-300">{progressPct}%</span>
+          </div>
+          <div className="h-3 w-full overflow-hidden rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progressPct}>
+            <div className="h-full rounded-full bg-cyan-500" style={{ width: `${progressPct}%` }} />
+          </div>
+          <p className="mt-2 text-xs text-slate-500">
+            {AUTOFINISH_COUNT.toLocaleString()} / {AUTOFINISH_TARGET.toLocaleString()} iteracija
+          </p>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-2" aria-label="Kljucne metrike">
+          <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="text-sm text-slate-400">Health score</h2>
+            <p className="mt-2 text-3xl font-bold text-emerald-300">{healthScore.score}%</p>
+            <p className="text-xs text-slate-500">{healthScore.status}</p>
+          </article>
+
+          <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="text-sm text-slate-400">Release readiness</h2>
+            <p className="mt-2 text-3xl font-bold text-indigo-300">{readiness.score}%</p>
+            <p className="text-xs text-slate-500">{readiness.status}</p>
+          </article>
+
+          <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="text-sm text-slate-400">Error budget</h2>
+            <p className="mt-2 text-3xl font-bold text-amber-300">{budget.preostalo}%</p>
+            <p className="text-xs text-slate-500">SLO: {budget.slo}%</p>
+          </article>
+
+          <article className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+            <h2 className="text-sm text-slate-400">DORA deploy frequency</h2>
+            <p className="mt-2 text-3xl font-bold text-fuchsia-300">{dora.deployFrequency}</p>
+            <p className="text-xs text-slate-500">Lead time: {dora.leadTime}</p>
+          </article>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900 p-6" aria-label="Brzi linkovi">
+          <h2 className="text-sm uppercase tracking-wider text-slate-400">Brzi linkovi</h2>
+          <div className="mt-3 flex flex-wrap gap-3 text-sm">
+            <a className="rounded-lg border border-cyan-600 px-3 py-1.5 text-cyan-300 hover:bg-cyan-950" href="/autofinish">
+              Otvori glavni dashboard
+            </a>
+            <a className="rounded-lg border border-slate-700 px-3 py-1.5 text-slate-300 hover:bg-slate-800" href="/api/autofinish-petlja">
+              API: petlja
+            </a>
+            <a className="rounded-lg border border-slate-700 px-3 py-1.5 text-slate-300 hover:bg-slate-800" href="/api/autofinish-release-readiness">
+              API: readiness
+            </a>
+          </div>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/src/app/autofinish/AutofinishCommandCenterWidget.tsx
+++ b/src/app/autofinish/AutofinishCommandCenterWidget.tsx
@@ -1,0 +1,58 @@
+type AutofinishCommandCenterWidgetProps = {
+  healthScore: {
+    score: number;
+    status: string;
+  };
+  readiness: {
+    score: number;
+    status: string;
+  };
+  dora: {
+    deployFrequency: string;
+    leadTime: string;
+    mttr: string;
+    changeFailureRate: string;
+  };
+  errorBudget: {
+    slo: number;
+    preostalo: number;
+    incidenti: number;
+  };
+};
+
+export function AutofinishCommandCenterWidget({
+  healthScore,
+  readiness,
+  dora,
+  errorBudget,
+}: AutofinishCommandCenterWidgetProps) {
+  return (
+    <section className="rounded-xl p-6 mb-6 bg-gray-900 border border-gray-800" aria-label="Autofinish command center">
+      <h2 className="text-lg font-semibold text-gray-300 mb-4">
+        <span aria-hidden="true">🛰️ </span>Autofinish Command Center
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <article className="rounded-lg bg-gray-800 p-3">
+          <p className="text-xs text-gray-400">Health</p>
+          <p className="text-2xl font-bold text-green-400">{healthScore.score}%</p>
+          <p className="text-xs text-gray-500">{healthScore.status}</p>
+        </article>
+        <article className="rounded-lg bg-gray-800 p-3">
+          <p className="text-xs text-gray-400">Readiness</p>
+          <p className="text-2xl font-bold text-indigo-300">{readiness.score}%</p>
+          <p className="text-xs text-gray-500">{readiness.status}</p>
+        </article>
+        <article className="rounded-lg bg-gray-800 p-3">
+          <p className="text-xs text-gray-400">Error budget</p>
+          <p className="text-2xl font-bold text-yellow-300">{errorBudget.preostalo}%</p>
+          <p className="text-xs text-gray-500">SLO {errorBudget.slo}% • Incidenti {errorBudget.incidenti}</p>
+        </article>
+        <article className="rounded-lg bg-gray-800 p-3">
+          <p className="text-xs text-gray-400">DORA</p>
+          <p className="text-sm font-semibold text-cyan-300">{dora.deployFrequency}</p>
+          <p className="text-xs text-gray-500">Lead {dora.leadTime} • MTTR {dora.mttr} • CFR {dora.changeFailureRate}</p>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/app/autofinish/page.tsx
+++ b/src/app/autofinish/page.tsx
@@ -136,6 +136,7 @@ import { ReleaseReadinessWidget } from './ReleaseReadinessWidget';
 import { AuditReportWidget } from './AuditReportWidget';
 import { SystemReportWidget } from './SystemReportWidget';
 import { SrbijaLicencniReportWidget } from './SrbijaLicencniReportWidget';
+import { AutofinishCommandCenterWidget } from './AutofinishCommandCenterWidget';
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://ai-iq-super-platforma.vercel.app';
 
@@ -281,6 +282,14 @@ export default function AutofinishPage() {
           <p className="text-gray-400 text-sm">
             {KOMPANIJA} — Verzija {APP_VERSION} — Iteracija #{AUTOFINISH_COUNT}
           </p>
+          <div className="mt-3">
+            <a
+              href="/autofinish-nexus"
+              className="inline-flex items-center rounded-md border border-cyan-700 px-3 py-1.5 text-xs font-semibold text-cyan-300 hover:bg-cyan-950 focus:outline-none focus:ring-2 focus:ring-cyan-400"
+            >
+              Otvori Autofinish Nexus
+            </a>
+          </div>
         </header>
 
         {/* Status kartica */}
@@ -737,6 +746,14 @@ export default function AutofinishPage() {
             </a>
           </div>
         </section>
+
+        {/* #978 — Kategorije Stats Widget */}
+        <AutofinishCommandCenterWidget
+          healthScore={healthScore}
+          readiness={releaseReadiness}
+          dora={doraMetrics}
+          errorBudget={errorBudget}
+        />
 
         {/* #978 — Kategorije Stats Widget */}
         <KategorijeStatsWidget


### PR DESCRIPTION
## Summary
- add new route `/autofinish-nexus` with key Autofinish operational metrics
- add `AutofinishCommandCenterWidget` and render it in existing `/autofinish` dashboard
- add quick link from `/autofinish` header to `/autofinish-nexus`

## Files changed
- `src/app/autofinish-nexus/page.tsx`
- `src/app/autofinish/AutofinishCommandCenterWidget.tsx`
- `src/app/autofinish/page.tsx`

## Notes
- TypeScript/Problems panel reports no errors for changed files.
- Tests were not run in this step.